### PR TITLE
fix: reset rc number when bump target differs from current rc base

### DIFF
--- a/bin/semver-next
+++ b/bin/semver-next
@@ -135,12 +135,17 @@ def main() -> None:
         next_version = base.bump_patch()
 
     if args.rc == "rc":
-        # If latest tag is already an rc (e.g. 1.3.0-rc.1), next is same base + rc.(N+1)
+        # If latest tag is already an rc for the same target base, increment rc number.
+        # Otherwise (e.g. minor bump requested but latest rc is for a patch), start at rc.1.
         if version_info.prerelease and RC_PRERELEASE_RE.match(version_info.prerelease):
             target_base = semver.VersionInfo(
                 version_info.major, version_info.minor, version_info.patch
             )
-            rc_num = next_rc_number(version_info, target_base)
+            if target_base == next_version:
+                rc_num = next_rc_number(version_info, target_base)
+            else:
+                target_base = next_version
+                rc_num = 1
         else:
             target_base = next_version
             rc_num = 1


### PR DESCRIPTION
## Summary

- When `semver-next` is invoked with `--rc rc` and the latest tag is an RC for a *different* version base than the requested bump target, the tool now correctly resets to `rc.1` for the new target instead of incrementing the old RC number.

## Example scenario fixed

- Latest tag: `v1.2.0-rc.3`
- Command: `semver-next --bump minor --rc rc`
- Before fix: could produce `v1.2.0-rc.4` (wrong base)
- After fix: produces `v1.3.0-rc.1` (correct)

## Test plan

- [x] Run `semver-next --bump minor --rc rc` against a repo where the latest tag is an RC for a lower version than the requested bump level
- [x] Confirm the output resets to `rc.1` for the correct target version
- [x] Confirm that incrementing within the same base (e.g. `v1.3.0-rc.2` → `v1.3.0-rc.3`) still works correctly