### PR TITLE
fix: make git-repostat resilient to stale remote HEAD

### DIFF
--- a/bin/git-repostat
+++ b/bin/git-repostat
@@ -91,30 +91,43 @@ def print_type(json, header, type, widths)
   end
 end
 
+def remote_branch_exists?(remote, branch)
+  system('git', 'show-ref', '--verify', '--quiet', "refs/remotes/#{remote}/#{branch}")
+end
+
 def find_sync_branch
   remotes = `git remote`.split
   remote = remotes.include?('upstream') ? 'upstream' : 'origin'
+  primary_branch = nil
 
   # Try to find the primary branch without networking
-  head_ref = `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null`.strip
+  head_ref = `git symbolic-ref refs/remotes/#{remote}/HEAD 2>/dev/null`.strip
   if !head_ref.empty?
-      primary_branch = head_ref.split('/').last
-  else
-      if `git rev-parse --verify origin/main 2>/dev/null`.strip != ""
-        primary_branch = "main"
-      elsif `git rev-parse --verify origin/master 2>/dev/null`.strip != ""
-        primary_branch = "master"
-      else
-        # Fallback to network call if absolutely necessary
-        primary_branch = `git remote show origin | grep 'HEAD branch' | cut -d' ' -f5 | xargs echo -n`
-      end
+    head_branch = head_ref.split('/').last
+    primary_branch = head_branch if remote_branch_exists?(remote, head_branch)
   end
+
+  if primary_branch == nil
+    remote_branches = `git for-each-ref --format="%(refname:strip=3)" refs/remotes/#{remote} 2>/dev/null`
+                        .split("\n")
+                        .reject { |branch| branch.empty? || branch == 'HEAD' }
+    primary_branch = %w[main master].find { |branch| remote_branches.include?(branch) }
+    primary_branch ||= remote_branches.first
+  end
+
+  if primary_branch == nil || primary_branch.empty?
+    # Fallback to network call if absolutely necessary
+    primary_branch = `git remote show #{remote} | grep 'HEAD branch' | cut -d' ' -f5 | xargs echo -n`
+  end
+
   "#{remote}/#{primary_branch}"
 end
 
 SYNC_BRANCH = find_sync_branch
 SYNC_REMOTE = SYNC_BRANCH.split('/')[0]
 SYNC_BRANCH_ONLY = SYNC_BRANCH.split('/')[1]
+SYNC_REMOTE_LABEL = "#{SYNC_REMOTE[0, 4]}+"
+SYNC_REMOTE_LABEL_NEG = "#{SYNC_REMOTE[0, 4]}-"
 
 # Fetch all refs, ages, ahead-behind vs sync branch, and tip metadata in one git call
 refs_output = `git for-each-ref --format="%(refname)%09%(committerdate:relative)%09%(ahead-behind:#{SYNC_BRANCH})%09%(objectname:short=8)%09%(authorname)" refs/heads refs/remotes`
@@ -140,12 +153,12 @@ refs_output.split("\n").each do |line|
     all_refs[short_name] = age
     all_ref_tips[short_name] = [short_sha, author].compact.join(' ').strip
     sync_ahead_behind[short_name] = { ahead: ahead, behind: behind }
-  elsif full_ref.start_with?('refs/remotes/origin/') && !full_ref.end_with?('/HEAD')
-    short_name = full_ref.sub('refs/remotes/origin/', '')
+  elsif full_ref.start_with?("refs/remotes/#{SYNC_REMOTE}/") && !full_ref.end_with?('/HEAD')
+    short_name = full_ref.sub("refs/remotes/#{SYNC_REMOTE}/", '')
     remote_branches << short_name
-    all_refs["origin/#{short_name}"] = age
-    all_ref_tips["origin/#{short_name}"] = [short_sha, author].compact.join(' ').strip
-    sync_ahead_behind["origin/#{short_name}"] = { ahead: ahead, behind: behind }
+    all_refs["#{SYNC_REMOTE}/#{short_name}"] = age
+    all_ref_tips["#{SYNC_REMOTE}/#{short_name}"] = [short_sha, author].compact.join(' ').strip
+    sync_ahead_behind["#{SYNC_REMOTE}/#{short_name}"] = { ahead: ahead, behind: behind }
   end
 end
 
@@ -159,7 +172,7 @@ data = [
         :type        => :header,
         :fix         => '# Cleanup Command',
         :branch      => 'Branch', :age => 'Age',
-        :aheadOrigin => 'orgn+', :behindOrigin => 'orgn-',
+        :aheadOrigin => SYNC_REMOTE_LABEL, :behindOrigin => SYNC_REMOTE_LABEL_NEG,
         :aheadSync   => 'trgt+', :behindSync => 'trgt-',
         :tip         => 'tip',
     }
@@ -182,38 +195,38 @@ local_only_branches.each do |name|
 end
 
 remote_only_branches.each do |name|
-  ab = sync_ahead_behind["origin/#{name}"]
+  ab = sync_ahead_behind["#{SYNC_REMOTE}/#{name}"]
   ret_val = {
       type:       :remote,
       branch:     name,
-      age:        all_refs["origin/#{name}"] || '',
+      age:        all_refs["#{SYNC_REMOTE}/#{name}"] || '',
       aheadSync:  ab[:ahead],
       behindSync: ab[:behind],
-      tip:        all_ref_tips["origin/#{name}"] || '',
+      tip:        all_ref_tips["#{SYNC_REMOTE}/#{name}"] || '',
   }
   if ret_val[:aheadSync] == 0 && !excluded_branches.include?(name)
-    ret_val[:fix] = "git push origin :#{name}"
+    ret_val[:fix] = "git push #{SYNC_REMOTE} :#{name}"
   end
   data.append ret_val
 end
 
-# For tracked branches, get origin ahead-behind in parallel threads
-origin_ahead_behind = {}
+# For tracked branches, get remote ahead-behind in parallel threads
+remote_ahead_behind = {}
 threads = tracked_branches.map do |name|
   Thread.new(name) do |n|
-    result = `git rev-list --left-right --count #{n}...origin/#{n} 2>/dev/null`.strip
+    result = `git rev-list --left-right --count #{n}...#{SYNC_REMOTE}/#{n} 2>/dev/null`.strip
     ahead, behind = result.split("\t").map(&:to_i)
     [n, ahead, behind]
   end
 end
 threads.each do |t|
   name, ahead, behind = t.value
-  origin_ahead_behind[name] = { ahead: ahead, behind: behind }
+  remote_ahead_behind[name] = { ahead: ahead, behind: behind }
 end
 
 tracked_branches.each do |name|
   ab_sync = sync_ahead_behind[name]
-  ab_origin = origin_ahead_behind[name]
+  ab_origin = remote_ahead_behind[name]
   ret_val = {
       type:         :tracked,
       branch:       name,
@@ -225,7 +238,7 @@ tracked_branches.each do |name|
       tip:          all_ref_tips[name] || '',
   }
   if ret_val[:aheadSync] == 0 && !excluded_branches.include?(name)
-    ret_val[:fix] = "git branch -D #{name}; git push origin :#{name}"
+    ret_val[:fix] = "git branch -D #{name}; git push #{SYNC_REMOTE} :#{name}"
   end
   data.append ret_val
 end


### PR DESCRIPTION
## Summary
- ignore dangling remote HEAD refs that still point at removed branches like `origin/master`
- fall back to real remote branches, preferring `main` and then `master`, before using a network lookup
- use the selected sync remote consistently when scanning remote refs, computing ahead/behind counts, and suggesting cleanup commands

## Verification
- `ruby -c bin/git-repostat`
- ran `bin/git-repostat` from a repo with mismatch and verified it now reports `TARGET: origin/main` without the `failed to find 'origin/master'` error
- created a scratch repo with both `origin` and `upstream` remotes and verified the script reports `TARGET: upstream/main` and uses the upstream remote consistently
